### PR TITLE
Removed warnings

### DIFF
--- a/src/compiler/scala/reflect/quasiquotes/Holes.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Holes.scala
@@ -132,7 +132,7 @@ trait Holes { self: Quasiquotes =>
     private def mapF(tree: Tree, f: Tree => Tree): Tree =
       if (f(Ident(TermName("x"))) equalsStructure Ident(TermName("x"))) tree
       else {
-        val x: TermName = c.freshName()
+        val x: TermName = TermName(c.freshName())
         // q"$tree.map { $x => ${f(Ident(x))} }"
         Apply(Select(tree, nme.map),
           Function(ValDef(Modifiers(PARAM), x, TypeTree(), EmptyTree) :: Nil,
@@ -187,7 +187,7 @@ trait Holes { self: Quasiquotes =>
     lazy val tree =
       tptopt.map { tpt =>
         val TypeDef(_, _, _, typedTpt) =
-          try c.typeCheck(TypeDef(NoMods, TypeName("T"), Nil, tpt))
+          try c.typecheck(TypeDef(NoMods, TypeName("T"), Nil, tpt))
           catch { case TypecheckException(pos, msg) => c.abort(pos.asInstanceOf[c.Position], msg) }
         val tpe = typedTpt.tpe
         val (iterableRank, _) = stripIterable(tpe)

--- a/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
@@ -247,7 +247,7 @@ trait Reifiers { self: Quasiquotes =>
         hole.tree
       case Placeholder(hole: UnapplyHole) => hole.treeNoUnlift
       case FreshName(prefix) if prefix != nme.QUASIQUOTE_NAME_PREFIX =>
-        def fresh() = c.freshName[TermName](nme.QUASIQUOTE_NAME_PREFIX)
+        def fresh() = c.freshName(TermName(nme.QUASIQUOTE_NAME_PREFIX))
         def introduceName() = { val n = fresh(); nameMap(name) += n; n}
         def result(n: Name) = if (isReifyingExpressions) Ident(n) else Bind(n, Ident(nme.WILDCARD))
         if (isReifyingPatterns) result(introduceName())

--- a/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
@@ -39,7 +39,7 @@ trait GenSymbols {
     else if (sym.isModuleClass)
       if (sym.sourceModule.isLocatable) Select(Select(reify(sym.sourceModule), nme.asModule), nme.moduleClass)
       else reifySymDef(sym)
-    else if (sym.isPackage)
+    else if (sym.hasPackageFlag)
       mirrorMirrorCall(nme.staticPackage, reify(sym.fullName))
     else if (sym.isLocatable) {
       /*  This is a fancy conundrum that stems from the fact that Scala allows

--- a/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
@@ -153,7 +153,7 @@ trait GenTrees {
         else mirrorCall(nme.Ident, reify(name))
 
       case Select(qual, name) =>
-        if (qual.symbol != null && qual.symbol.isPackage) {
+        if (qual.symbol != null && qual.symbol.hasPackageFlag) {
           mirrorBuildCall(nme.mkIdent, reify(sym))
         } else {
           val effectiveName = if (sym != null && sym != NoSymbol) sym.name else name
@@ -199,7 +199,7 @@ trait GenTrees {
           }
         }
         else tree match {
-          case Select(qual, name) if !qual.symbol.isPackage =>
+          case Select(qual, name) if !qual.symbol.hasPackageFlag =>
             if (reifyDebug) println(s"reifying Select($qual, $name)")
             mirrorCall(nme.Select, reify(qual), reify(name))
           case SelectFromTypeTree(qual, name) =>

--- a/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
@@ -15,7 +15,7 @@ trait GenUtils {
   def reifyProduct(prefix: String, elements: List[Any]): Tree = {
     // reflection would be more robust, but, hey, this is a hot path
     if (prefix.startsWith("Tuple")) scalaFactoryCall(prefix, (elements map reify).toList: _*)
-    else mirrorCall(prefix, (elements map reify): _*)
+    else mirrorCall(TermName(prefix), (elements map reify): _*)
   }
 
   // helper functions
@@ -49,16 +49,16 @@ trait GenUtils {
     call("" + nme.MIRROR_PREFIX + name, args: _*)
 
   def mirrorFactoryCall(value: Product, args: Tree*): Tree =
-    mirrorFactoryCall(value.productPrefix, args: _*)
+    mirrorFactoryCall(TermName(value.productPrefix), args: _*)
 
   def mirrorFactoryCall(prefix: TermName, args: Tree*): Tree =
-    mirrorCall("" + prefix, args: _*)
+    mirrorCall(prefix, args: _*)
 
   def scalaFactoryCall(name: TermName, args: Tree*): Tree =
     call(s"scala.$name.apply", args: _*)
 
   def scalaFactoryCall(name: String, args: Tree*): Tree =
-    scalaFactoryCall(name: TermName, args: _*)
+    scalaFactoryCall(TermName(name), args: _*)
 
   def mkList(args: List[Tree]): Tree =
     scalaFactoryCall("collection.immutable.List", args: _*)

--- a/src/compiler/scala/tools/ant/FastScalac.scala
+++ b/src/compiler/scala/tools/ant/FastScalac.scala
@@ -15,7 +15,7 @@ import org.apache.tools.ant.types.Path
 import scala.tools.nsc.Settings
 import scala.tools.nsc.io.File
 import scala.tools.nsc.settings.FscSettings
-import scala.tools.nsc.util.ScalaClassLoader
+import scala.reflect.internal.util.ScalaClassLoader
 
 /** An Ant task to compile with the fast Scala compiler (`fsc`).
  *

--- a/src/compiler/scala/tools/ant/sabbus/Compiler.scala
+++ b/src/compiler/scala/tools/ant/sabbus/Compiler.scala
@@ -12,7 +12,7 @@ package scala.tools.ant.sabbus
 import java.io.File
 import java.net.URL
 import java.lang.reflect.InvocationTargetException
-import scala.tools.nsc.util.ScalaClassLoader
+import scala.reflect.internal.util.ScalaClassLoader
 
 class Compiler(classpath: Array[URL], val settings: Settings)
 {

--- a/src/compiler/scala/tools/ant/sabbus/ScalacFork.scala
+++ b/src/compiler/scala/tools/ant/sabbus/ScalacFork.scala
@@ -16,7 +16,7 @@ import org.apache.tools.ant.taskdefs.Java
 import org.apache.tools.ant.util.{ GlobPatternMapper, SourceFileScanner }
 import org.apache.tools.ant.BuildException
 import scala.tools.nsc.io
-import scala.tools.nsc.util.ScalaClassLoader
+import scala.reflect.internal.util.ScalaClassLoader
 
 /** An Ant task to compile with the new Scala compiler (NSC).
  *

--- a/src/compiler/scala/tools/nsc/EvalLoop.scala
+++ b/src/compiler/scala/tools/nsc/EvalLoop.scala
@@ -6,6 +6,7 @@
 package scala.tools.nsc
 
 import scala.annotation.tailrec
+import scala.io.StdIn
 import java.io.EOFException
 
 trait EvalLoop {
@@ -14,7 +15,7 @@ trait EvalLoop {
   def loop(action: (String) => Unit) {
     @tailrec def inner() {
       Console.print(prompt)
-      val line = try Console.readLine() catch { case _: EOFException => null }
+      val line = try StdIn.readLine() catch { case _: EOFException => null }
       if (line != null && line != "") {
         action(line)
         inner()

--- a/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
@@ -6,6 +6,7 @@
 package scala.tools.nsc
 
 import GenericRunnerCommand._
+import scala.reflect.internal.util.ScalaClassLoader
 
 /** A command for ScriptRunner */
 class GenericRunnerCommand(
@@ -32,7 +33,7 @@ extends CompilerCommand(args, settings) {
   private def guessHowToRun(target: String): GenericRunnerCommand.HowToRun = {
     if (!ok) Error
     else if (io.Jar.isJarOrZip(target)) AsJar
-    else if (util.ScalaClassLoader.classExists(settings.classpathURLs, target)) AsObject
+    else if (ScalaClassLoader.classExists(settings.classpathURLs, target)) AsObject
     else {
       val f = io.File(target)
       if (!f.hasExtension("class", "jar", "zip") && f.canRead) AsScript

--- a/src/compiler/scala/tools/nsc/ObjectRunner.scala
+++ b/src/compiler/scala/tools/nsc/ObjectRunner.scala
@@ -7,8 +7,8 @@
 package scala.tools.nsc
 
 import java.net.URL
-import util.ScalaClassLoader
 import util.Exceptional.unwrap
+import scala.reflect.internal.util.ScalaClassLoader
 
 trait CommonRunner {
   /** Run a given object, specified by name, using a

--- a/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
+++ b/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
@@ -9,6 +9,7 @@ package ast
 import scala.compat.Platform.EOL
 import symtab.Flags._
 import scala.language.postfixOps
+import scala.reflect.internal.util.ListOfNil
 
 /** The object `nodePrinter` converts the internal tree
  *  representation to a string.

--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -308,7 +308,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
                 // Erasing locally-defined symbols is useful to prevent tree corruption, but erasing external bindings is not,
                 // therefore we want to retain those bindings, especially given that restoring them can be impossible
                 // if we move these trees into lexical contexts different from their original locations.
-                if (dupl.hasSymbol) {
+                if (dupl.hasSymbolField) {
                   val sym = dupl.symbol
                   val vetoScope = !brutally && !(locals contains sym) && !(locals contains sym.deSkolemize)
                   val vetoThis = dupl.isInstanceOf[This] && sym.isPackageClass

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -13,7 +13,7 @@ import scala.collection.{ mutable, immutable }
 import mutable.{ ListBuffer, StringBuilder }
 import scala.reflect.internal.{ Precedence, ModifierFlags => Flags }
 import scala.reflect.internal.Chars.{ isScalaLetter }
-import scala.reflect.internal.util.{ SourceFile, Position, FreshNameCreator }
+import scala.reflect.internal.util.{ SourceFile, Position, FreshNameCreator, ListOfNil }
 import Tokens._
 
 /** Historical note: JavaParsers started life as a direct copy of Parsers
@@ -2788,7 +2788,7 @@ self =>
      */
     def packageObjectDef(start: Offset): PackageDef = {
       val defn   = objectDef(in.offset, NoMods)
-      val pidPos = o2p(defn.pos.startOrPoint)
+      val pidPos = o2p(defn.pos.start)
       val pkgPos = r2p(start, pidPos.point)
       gen.mkPackageObject(defn, pidPos, pkgPos)
     }

--- a/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
@@ -8,6 +8,7 @@ package ast.parser
 
 import scala.collection.{ mutable, immutable }
 import symtab.Flags.MUTABLE
+import scala.reflect.internal.util.ListOfNil
 import scala.reflect.internal.util.StringOps.splitWhere
 
 /** This class builds instance of `Tree` that represent XML.

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -613,9 +613,8 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
                  */
                 for (i <- args.length until dims) elemKind = ArrayBType(elemKind)
               }
-              (argsSize : @switch) match {
-                case 1 => bc newarray elemKind
-                case _ =>
+              if (argsSize == 1) bc newarray elemKind
+              else {
                   val descr = ('[' * argsSize) + elemKind.descriptor // denotes the same as: arrayN(elemKind, argsSize).descriptor
                   mnode.visitMultiANewArrayInsn(descr, argsSize)
               }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -427,7 +427,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
          */
 
         case tp =>
-          currentUnit.warning(tp.typeSymbol.pos,
+          typer.context.warning(tp.typeSymbol.pos,
             s"an unexpected type representation reached the compiler backend while compiling $currentUnit: $tp. " +
             "If possible, please file a bug on issues.scala-lang.org.")
 
@@ -861,8 +861,8 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
       var fieldList = List[String]()
 
       for (f <- fieldSymbols if f.hasGetter;
-	         g = f.getter(cls);
-	         s = f.setter(cls);
+	         g = f.getterIn(cls);
+	         s = f.setterIn(cls);
 	         if g.isPublic && !(f.name startsWith "$")
           ) {
              // inserting $outer breaks the bean

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -13,6 +13,7 @@ import symtab.Flags
 import JavaTokens._
 import scala.language.implicitConversions
 import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.ListOfNil
 
 trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
   val global : Global
@@ -125,7 +126,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
     def makeSyntheticParam(count: Int, tpt: Tree): ValDef =
       makeParam(nme.syntheticParamName(count), tpt)
     def makeParam(name: String, tpt: Tree): ValDef =
-      makeParam(name: TermName, tpt)
+      makeParam(TermName(name), tpt)
     def makeParam(name: TermName, tpt: Tree): ValDef =
       ValDef(Modifiers(Flags.JAVA | Flags.PARAM), name, tpt, EmptyTree)
 

--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -7,7 +7,7 @@ package scala.tools.nsc
 package plugins
 
 import scala.tools.nsc.io.{ Jar }
-import scala.tools.nsc.util.ScalaClassLoader
+import scala.reflect.internal.util.ScalaClassLoader
 import scala.reflect.io.{ Directory, File, Path }
 import java.io.InputStream
 import java.util.zip.ZipException
@@ -60,13 +60,13 @@ abstract class Plugin {
    *  @return true to continue, or false to opt out
    */
   def init(options: List[String], error: String => Unit): Boolean = {
-    processOptions(options, error)
+    if (!options.isEmpty) error(s"Error: $name takes no options")
     true
   }
 
   @deprecated("use Plugin#init instead", since="2.11")
   def processOptions(options: List[String], error: String => Unit): Unit = {
-    if (!options.isEmpty) error(s"Error: $name takes no options")
+    init(options, error)
   }
 
   /** A description of this plugin's options, suitable as a response

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -807,10 +807,10 @@ abstract class ClassfileParser {
           val c = pool.getConstant(u2)
           val c1 = convertTo(c, symtype)
           if (c1 ne null) sym.setInfo(ConstantType(c1))
-          else debugwarn(s"failure to convert $c to $symtype")
+          else devWarning(s"failure to convert $c to $symtype")
         case tpnme.ScalaSignatureATTR =>
           if (!isScalaAnnot) {
-            debugwarn(s"symbol ${sym.fullName} has pickled signature in attribute")
+            devWarning(s"symbol ${sym.fullName} has pickled signature in attribute")
             unpickler.unpickle(in.buf, in.bp, clazz, staticModule, in.file.name)
           }
           in.skip(attrLen)
@@ -1103,7 +1103,7 @@ abstract class ClassfileParser {
     def enclosing    = if (jflags.isStatic) enclModule else enclClass
 
     // The name of the outer class, without its trailing $ if it has one.
-    private def strippedOuter = nme stripModuleSuffix outerName
+    private def strippedOuter = outerName.dropModule
     private def isInner       = innerClasses contains strippedOuter
     private def enclClass     = if (isInner) innerClasses innerSymbol strippedOuter else classNameToSymbol(strippedOuter)
     private def enclModule    = enclClass.companionModule
@@ -1123,7 +1123,7 @@ abstract class ClassfileParser {
 
     def add(entry: InnerClassEntry): Unit = {
       inners get entry.externalName foreach (existing =>
-        debugwarn(s"Overwriting inner class entry! Was $existing, now $entry")
+        devWarning(s"Overwriting inner class entry! Was $existing, now $entry")
       )
       inners(entry.externalName) = entry
     }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -74,7 +74,7 @@ abstract class ICodeReader extends ClassfileParser {
             first != CONSTANT_METHODREF &&
             first != CONSTANT_INTFMETHODREF) errorBadTag(start)
         val ownerTpe = getClassOrArrayType(in.getChar(start + 1).toInt)
-        debuglog("getMemberSymbol(static: " + static + "): owner type: " + ownerTpe + " " + ownerTpe.typeSymbol.originalName)
+        debuglog("getMemberSymbol(static: " + static + "): owner type: " + ownerTpe + " " + ownerTpe.typeSymbol.unexpandedName)
         val (name0, tpe0) = getNameAndType(in.getChar(start + 3).toInt, ownerTpe)
         debuglog("getMemberSymbol: name and tpe: " + name0 + ": " + tpe0)
 

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -8,6 +8,7 @@ package transform
 
 import scala.collection.{ mutable, immutable }
 import scala.collection.mutable.ListBuffer
+import scala.reflect.internal.util.ListOfNil
 import symtab.Flags._
 
 /** This phase converts classes with parameters into Java-like classes with

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1036,7 +1036,7 @@ abstract class Erasure extends AddInterfaces
                 //    See SI-5568.
                 tree setSymbol Object_getClass
               } else {
-                debugwarn(s"The symbol '${fn.symbol}' was interecepted but didn't match any cases, that means the intercepted methods set doesn't match the code")
+                devWarning(s"The symbol '${fn.symbol}' was interecepted but didn't match any cases, that means the intercepted methods set doesn't match the code")
                 tree
               }
             } else qual match {

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -207,7 +207,7 @@ abstract class ExplicitOuter extends InfoTransform
       // class needs to have a common naming scheme, independently of whether
       // the field was accessed from an inner class or not. See #2946
       if (sym.owner.isTrait && sym.isLocalToThis &&
-              (sym.getter(sym.owner.toInterface) == NoSymbol))
+              (sym.getterIn(sym.owner.toInterface) == NoSymbol))
         sym.makeNotPrivate(sym.owner)
       tp
   }

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -699,7 +699,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
         } else if (m.isValue && !m.isMethod && !m.hasFlag(LAZY)) { // concrete value definition
           def mkAccessor(field: Symbol, name: Name) = {
-            val newFlags = (SPECIALIZED | m.getter(clazz).flags) & ~(LOCAL | CASEACCESSOR | PARAMACCESSOR)
+            val newFlags = (SPECIALIZED | m.getterIn(clazz).flags) & ~(LOCAL | CASEACCESSOR | PARAMACCESSOR)
             // we rely on the super class to initialize param accessors
             val sym = sClass.newMethod(name.toTermName, field.pos, newFlags)
             info(sym) = SpecializedAccessor(field)
@@ -720,7 +720,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
           if (nme.isLocalName(m.name)) {
             val specGetter = mkAccessor(specVal, specVal.getterName) setInfo MethodType(Nil, specVal.info)
-            val origGetter = overrideIn(sClass, m.getter(clazz))
+            val origGetter = overrideIn(sClass, m.getterIn(clazz))
             info(origGetter) = Forward(specGetter)
             enterMember(specGetter)
             enterMember(origGetter)
@@ -733,12 +733,12 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
               debuglog("override case field accessor %s -> %s".format(m.name.decode, cfaGetter.name.decode))
             }
 
-            if (specVal.isVariable && m.setter(clazz) != NoSymbol) {
+            if (specVal.isVariable && m.setterIn(clazz) != NoSymbol) {
               val specSetter = mkAccessor(specVal, specGetter.setterName)
                 .resetFlag(STABLE)
               specSetter.setInfo(MethodType(specSetter.newSyntheticValueParams(List(specVal.info)),
                                             UnitTpe))
-              val origSetter = overrideIn(sClass, m.setter(clazz))
+              val origSetter = overrideIn(sClass, m.setterIn(clazz))
               info(origSetter) = Forward(specSetter)
               enterMember(specSetter)
               enterMember(origSetter)

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -10,6 +10,7 @@ package transform
 import symtab.Flags._
 import scala.collection.{ mutable, immutable }
 import scala.language.postfixOps
+import scala.reflect.internal.util.ListOfNil
 
 /*<export> */
 /** - uncurry all symbol and tree types (@see UnCurryPhase) -- this includes normalizing all proper types.
@@ -206,7 +207,7 @@ abstract class UnCurry extends InfoTransform
         // (() => Int) { def apply(): Int @typeConstraint }
         case RefinedType(List(funTp), decls) =>
           debuglog(s"eliminate refinement from function type ${fun.tpe}")
-          fun.tpe = funTp
+          fun.setType(funTp)
         case _ =>
           ()
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -276,7 +276,7 @@ trait Implicits {
   /** An extractor for types of the form ? { name: (? >: argtpe <: Any*)restp }
    */
   object HasMethodMatching {
-    val dummyMethod = NoSymbol.newTermSymbol("typer$dummy") setInfo NullaryMethodType(AnyTpe)
+    val dummyMethod = NoSymbol.newTermSymbol(TermName("typer$dummy")) setInfo NullaryMethodType(AnyTpe)
 
     def templateArgType(argtpe: Type) = new BoundedWildcardType(TypeBounds.lower(argtpe))
 
@@ -893,7 +893,7 @@ trait Implicits {
               try improves(firstPending, alt)
               catch {
                 case e: CyclicReference =>
-                  debugwarn(s"Discarding $firstPending during implicit search due to cyclic reference.")
+                  devWarning(s"Discarding $firstPending during implicit search due to cyclic reference.")
                   true
               }
             )

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -3,13 +3,14 @@ package typechecker
 
 import java.lang.Math.min
 import symtab.Flags._
-import scala.tools.nsc.util._
+import scala.reflect.internal.util.ScalaClassLoader
 import scala.reflect.runtime.ReflectionUtils
 import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
 import scala.reflect.internal.util.Statistics
 import scala.reflect.macros.util._
 import scala.util.control.ControlThrowable
+import scala.reflect.internal.util.ListOfNil
 import scala.reflect.macros.runtime.{AbortMacroException, MacroRuntimes}
 import scala.reflect.runtime.{universe => ru}
 import scala.reflect.macros.compiler.DefaultMacroCompiler

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -8,6 +8,7 @@ package typechecker
 import symtab.Flags._
 import scala.reflect.internal.util.StringOps.{ ojoin }
 import scala.reflect.ClassTag
+import scala.reflect.internal.util.ListOfNil
 import scala.reflect.runtime.{ universe => ru }
 import scala.language.higherKinds
 
@@ -384,7 +385,7 @@ trait MethodSynthesis {
       }
     }
     case class Getter(tree: ValDef) extends BaseGetter(tree) {
-      override def derivedSym = if (mods.isDeferred) basisSym else basisSym.getter(enclClass)
+      override def derivedSym = if (mods.isDeferred) basisSym else basisSym.getterIn(enclClass)
       private def derivedRhs  = if (mods.isDeferred) EmptyTree else fieldSelection
       private def derivedTpt = {
         // For existentials, don't specify a type for the getter, even one derived
@@ -451,7 +452,7 @@ trait MethodSynthesis {
       def flagsMask  = SetterFlags
       def flagsExtra = ACCESSOR
 
-      override def derivedSym = basisSym.setter(enclClass)
+      override def derivedSym = basisSym.setterIn(enclClass)
     }
     case class Field(tree: ValDef) extends DerivedFromValDef {
       def name       = tree.localName

--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -268,7 +268,7 @@ trait PatternTypers {
 
       def freshArgType(tp: Type): Type = tp match {
         case MethodType(param :: _, _) => param.tpe
-        case PolyType(tparams, restpe) => createFromClonedSymbols(tparams, freshArgType(restpe))(polyType)
+        case PolyType(tparams, restpe) => createFromClonedSymbols(tparams, freshArgType(restpe))(genPolyType)
         case OverloadedType(_, _)      => OverloadedUnapplyError(fun) ; ErrorType
         case _                         => UnapplyWithSingleArgError(fun) ; ErrorType
       }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -718,7 +718,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
 
           // Check the remainder for invalid absoverride.
           for (member <- rest ; if (member.isAbstractOverride && member.isIncompleteIn(clazz))) {
-            val other = member.superSymbol(clazz)
+            val other = member.superSymbolIn(clazz)
             val explanation =
               if (other != NoSymbol) " and overrides incomplete superclass member " + infoString(other)
               else ", but no concrete implementation could be found in a base class"
@@ -1684,9 +1684,9 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
               case _ =>
             }
             if (skipBounds) {
-              tree.tpe = tree.tpe.map {
+              tree.setType(tree.tpe.map {
                 _.filterAnnotations(_.symbol != UncheckedBoundsClass)
-              }
+              })
             }
 
             tree

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -344,7 +344,7 @@ trait SyntheticMethods extends ast.TreeDSL {
               // Without a means to suppress this warning, I've thought better of it.
               if (settings.warnValueOverrides) {
                  (clazz.info nonPrivateMember m.name) filter (m => (m.owner != AnyClass) && (m.owner != clazz) && !m.isDeferred) andAlso { m =>
-                   currentUnit.warning(clazz.pos, s"Implementation of ${m.name} inherited from ${m.owner} overridden in $clazz to enforce value class semantics")
+                   typer.context.warning(clazz.pos, s"Implementation of ${m.name} inherited from ${m.owner} overridden in $clazz to enforce value class semantics")
                  }
                }
               true

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -301,8 +301,8 @@ abstract class TreeCheckers extends Analyzer {
                   checkSym(tree)
                   /* XXX: lots of syms show up here with accessed == NoSymbol. */
                   if (accessed != NoSymbol) {
-                    val agetter = accessed.getter(sym.owner)
-                    val asetter = accessed.setter(sym.owner)
+                    val agetter = accessed.getterIn(sym.owner)
+                    val asetter = accessed.setterIn(sym.owner)
 
                     assertFn(agetter == sym || asetter == sym,
                       sym + " is getter or setter, but accessed sym " + accessed + " shows " + agetter + " and " + asetter
@@ -312,7 +312,7 @@ abstract class TreeCheckers extends Analyzer {
             }
           case ValDef(_, _, _, _) =>
             if (sym.hasGetter && !sym.isOuterField && !sym.isOuterAccessor) {
-              assertFn(sym.getter(sym.owner) != NoSymbol, ownerstr(sym) + " has getter but cannot be found. " + sym.ownerChain)
+              assertFn(sym.getterIn(sym.owner) != NoSymbol, ownerstr(sym) + " has getter but cannot be found. " + sym.ownerChain)
             }
           case Apply(fn, args) =>
             if (args exists (_ == EmptyTree))

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -141,8 +141,8 @@ trait TypeDiagnostics {
     if (!member.hasAccessorFlag) member
     else if (!member.isDeferred) member.accessed
     else {
-      val getter = if (member.isSetter) member.getter(member.owner) else member
-      val flags  = if (getter.setter(member.owner) != NoSymbol) DEFERRED.toLong | MUTABLE else DEFERRED
+      val getter = if (member.isSetter) member.getterIn(member.owner) else member
+      val flags  = if (getter.setterIn(member.owner) != NoSymbol) DEFERRED.toLong | MUTABLE else DEFERRED
 
       getter.owner.newValue(getter.name.toTermName, getter.pos, flags) setInfo getter.tpe.resultType
     }
@@ -439,7 +439,8 @@ trait TypeDiagnostics {
       context.warning(pos, "imported `%s' is permanently hidden by definition of %s".format(hidden, defn.fullLocationString))
 
     object checkUnused {
-      val ignoreNames = Set[TermName]("readResolve", "readObject", "writeObject", "writeReplace")
+      val ignoreNames = Set("readResolve", "readObject", "writeObject", "writeReplace")
+        .map(TermName.apply)
 
       class UnusedPrivates extends Traverser {
         val defnTrees = ListBuffer[MemberDef]()

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -14,7 +14,7 @@ package tools.nsc
 package typechecker
 
 import scala.collection.{mutable, immutable}
-import scala.reflect.internal.util.{ BatchSourceFile, Statistics, shortClassOfInstance }
+import scala.reflect.internal.util.{ BatchSourceFile, Statistics, shortClassOfInstance, ListOfNil }
 import mutable.ListBuffer
 import symtab.Flags._
 import Mode._
@@ -241,7 +241,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       case TypeRef(_, sym, _) if sym.isAliasType =>
         val tp0 = tp.dealias
         if (tp eq tp0) {
-          debugwarn(s"dropExistential did not progress dealiasing $tp, see SI-7126")
+          devWarning(s"dropExistential did not progress dealiasing $tp, see SI-7126")
           tp
         } else {
           val tp1 = dropExistential(tp0)
@@ -2026,7 +2026,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (mexists(vparamss)(_.symbol == superArg.symbol)) {
             val alias = (
               superAcc.initialize.alias
-                orElse (superAcc getter superAcc.owner)
+                orElse (superAcc getterIn superAcc.owner)
                 filter (alias => superClazz.info.nonPrivateMember(alias.name) == alias)
             )
             if (alias.exists && !alias.accessed.isVariable && !isRepeatedParamType(alias.accessed.info)) {
@@ -2547,7 +2547,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val default = methodSym newValueParameter (newTermName("default"), tree.pos.focus, SYNTHETIC) setInfo functionType(List(A1.tpe), B1.tpe)
 
         val paramSyms = List(x, default)
-        methodSym setInfo polyType(List(A1, B1), MethodType(paramSyms, B1.tpe))
+        methodSym setInfo genPolyType(List(A1, B1), MethodType(paramSyms, B1.tpe))
 
         val methodBodyTyper = newTyper(context.makeNewScope(context.tree, methodSym))
         if (!paramSynthetic) methodBodyTyper.context.scope enter x
@@ -2847,7 +2847,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         ClassDef(Modifiers(FINAL), tpnme.ANON_FUN_NAME, tparams = Nil,
           gen.mkTemplate(
             parents    = TypeTree(samClassTpFullyDefined) :: serializableParentAddendum,
-            self       = emptyValDef,
+            self       = noSelfType,
             constrMods = NoMods,
             vparamss   = ListOfNil,
             body       = List(samDef),
@@ -2916,7 +2916,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         var issuedMissingParameterTypeError = false
         foreach2(fun.vparams, argpts) { (vparam, argpt) =>
           if (vparam.tpt.isEmpty) {
-            vparam.tpt.tpe =
+            val vparamType =
               if (isFullyDefined(argpt)) argpt
               else {
                 fun match {
@@ -2935,6 +2935,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 issuedMissingParameterTypeError = true
                 ErrorType
               }
+            vparam.tpt.setType(vparamType)
             if (!vparam.tpt.pos.isDefined) vparam.tpt setPos vparam.pos.focus
           }
         }
@@ -4347,7 +4348,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         def narrowRhs(tp: Type) = { val sym = context.tree.symbol
           context.tree match {
             case ValDef(mods, _, _, Apply(Select(`tree`, _), _)) if !mods.isMutable && sym != null && sym != NoSymbol =>
-              val sym1 = if (sym.owner.isClass && sym.getter(sym.owner) != NoSymbol) sym.getter(sym.owner)
+              val sym1 = if (sym.owner.isClass && sym.getterIn(sym.owner) != NoSymbol) sym.getterIn(sym.owner)
                 else sym.lazyAccessorOrSelf
               val pre = if (sym1.owner.isClass) sym1.owner.thisType else NoPrefix
               intersectionType(List(tp, singleType(pre, sym1)))
@@ -5175,7 +5176,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           def warn(message: String)         = context.warning(lit.pos, s"possible missing interpolator: $message")
           def suspiciousSym(name: TermName) = context.lookupSymbol(name, _ => true).symbol
           def suspiciousExpr                = InterpolatorCodeRegex findFirstIn s
-          def suspiciousIdents              = InterpolatorIdentRegex findAllIn s map (s => suspiciousSym(s drop 1))
+          def suspiciousIdents              = InterpolatorIdentRegex findAllIn s map (s => suspiciousSym(TermName(s drop 1)))
 
           // heuristics - no warning on e.g. a string with only "$asInstanceOf"
           if (s contains ' ') (
@@ -5361,8 +5362,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       )
       def runTyper(): Tree = {
         if (retypingOk) {
-          tree.tpe = null
-          if (tree.hasSymbol) tree.symbol = NoSymbol
+          tree.setType(null)
+          if (tree.hasSymbolField) tree.symbol = NoSymbol
         }
         val alreadyTyped = tree.tpe ne null
         val shouldPrint = !alreadyTyped && !phase.erasedTypes

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -7,6 +7,7 @@ package scala.tools.nsc
 package typechecker
 
 import symtab.Flags._
+import scala.reflect.internal.util.ListOfNil
 
 /*
  *  @author  Martin Odersky

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -7,7 +7,7 @@ import scala.tools.nsc.Global
 import scala.tools.nsc.reporters._
 import scala.tools.nsc.CompilerCommand
 import scala.tools.nsc.io.{AbstractFile, VirtualDirectory}
-import scala.tools.nsc.util.AbstractFileClassLoader
+import scala.reflect.internal.util.AbstractFileClassLoader
 import scala.reflect.internal.Flags._
 import scala.reflect.internal.util.{BatchSourceFile, NoSourceFile, NoFile}
 import java.lang.{Class => jClass}

--- a/src/library/scala/runtime/BoxesRunTime.java
+++ b/src/library/scala/runtime/BoxesRunTime.java
@@ -28,7 +28,7 @@ import scala.math.ScalaNumber;
   * @version 2.0 */
 public final class BoxesRunTime
 {
-    private static final int CHAR = 0, BYTE = 1, SHORT = 2, INT = 3, LONG = 4, FLOAT = 5, DOUBLE = 6, OTHER = 7;
+    private static final int CHAR = 0, /* BYTE = 1, SHORT = 2, */ INT = 3, LONG = 4, FLOAT = 5, DOUBLE = 6, OTHER = 7;
 
     /** We don't need to return BYTE and SHORT, as everything which might
      *  care widens to INT.
@@ -41,10 +41,6 @@ public final class BoxesRunTime
         if (a instanceof java.lang.Float) return FLOAT;
         if ((a instanceof java.lang.Byte) || (a instanceof java.lang.Short)) return INT;
         return OTHER;
-    }
-
-    private static String boxDescription(Object a) {
-      return "" + a.getClass().getSimpleName() + "(" + a + ")";
     }
 
 /* BOXING ... BOXING ... BOXING ... BOXING ... BOXING ... BOXING ... BOXING ... BOXING */

--- a/src/reflect/scala/reflect/api/StandardLiftables.scala
+++ b/src/reflect/scala/reflect/api/StandardLiftables.scala
@@ -230,6 +230,6 @@ trait StandardLiftables { self: Universe =>
     val Symbol     = TermName("Symbol")
     val util       = TermName("util")
     val Vector     = TermName("Vector")
-    val WILDCARD   = self.nme.WILDCARD
+    val WILDCARD   = self.termNames.WILDCARD
   }
 }

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -2661,7 +2661,7 @@ trait Trees { self: Universe =>
    *  @group Traversal
    */
   abstract class ModifiersExtractor {
-    def apply(): Modifiers = Modifiers(NoFlags, tpnme.EMPTY, List())
+    def apply(): Modifiers = Modifiers(NoFlags, typeNames.EMPTY, List())
     def apply(flags: FlagSet, privateWithin: Name, annotations: List[Tree]): Modifiers
     def unapply(mods: Modifiers): Option[(FlagSet, Name, List[Tree])]
   }
@@ -2674,7 +2674,7 @@ trait Trees { self: Universe =>
   /** The factory for `Modifiers` instances.
    *  @group Traversal
    */
-  def Modifiers(flags: FlagSet): Modifiers = Modifiers(flags, tpnme.EMPTY)
+  def Modifiers(flags: FlagSet): Modifiers = Modifiers(flags, typeNames.EMPTY)
 
   /** An empty `Modifiers` object: no flags, empty visibility annotation and no Scala annotations.
    *  @group Traversal

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -469,7 +469,7 @@ trait Types {
     def unapply(tpe: SingleType): Option[(Type, Symbol)]
 
     /** @see [[InternalApi.singleType]] */
-    @deprecated("Use `ClassSymbol.thisPrefix` or `internal.singleType` instead")
+    @deprecated("Use `ClassSymbol.thisPrefix` or `internal.singleType` instead", "2.11.0")
     def apply(pre: Type, sym: Symbol)(implicit token: CompatToken): Type = internal.singleType(pre, sym)
   }
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -154,6 +154,9 @@ trait Definitions extends api.StandardDefinitions {
     private var isInitialized = false
     def isDefinitionsInitialized = isInitialized
 
+    private def getPackage(fullname: String): ModuleSymbol =
+      rootMirror.getPackage(TermName(fullname))
+    
     // It becomes tricky to create dedicated objects for other symbols because
     // of initialization order issues.
     lazy val JavaLangPackage      = getPackage("java.lang")
@@ -453,7 +456,7 @@ trait Definitions extends api.StandardDefinitions {
 
     // XML
     lazy val ScalaXmlTopScope = getModuleIfDefined("scala.xml.TopScope")
-    lazy val ScalaXmlPackage  = getPackageIfDefined("scala.xml")
+    lazy val ScalaXmlPackage  = getPackageIfDefined(TermName("scala.xml"))
 
     // scala.reflect
     lazy val ReflectPackage              = requiredModule[scala.reflect.`package`.type]
@@ -1462,7 +1465,7 @@ trait Definitions extends api.StandardDefinitions {
       )
       lazy val TagSymbols = TagMaterializers.keySet
       lazy val Predef_conforms     = (getMemberIfDefined(PredefModule, nme.conforms)
-                               orElse getMemberMethod(PredefModule, "conforms": TermName)) // TODO: predicate on -Xsource:2.10 (for now, needed for transition from M8 -> RC1)
+                               orElse getMemberMethod(PredefModule, TermName("conforms"))) // TODO: predicate on -Xsource:2.10 (for now, needed for transition from M8 -> RC1)
       lazy val Predef_classOf      = getMemberMethod(PredefModule, nme.classOf)
       lazy val Predef_implicitly   = getMemberMethod(PredefModule, nme.implicitly)
       lazy val Predef_wrapRefArray = getMemberMethod(PredefModule, nme.wrapRefArray)

--- a/src/reflect/scala/reflect/internal/Importers.scala
+++ b/src/reflect/scala/reflect/internal/Importers.scala
@@ -301,7 +301,7 @@ trait Importers { to: SymbolTable =>
           case (their: from.TypeTree, my: to.TypeTree) =>
             if (their.wasEmpty) my.defineType(importType(their.tpe)) else my.setType(importType(their.tpe))
           case (_, _) =>
-            my.tpe = importType(their.tpe)
+            my.setType(importType(their.tpe))
         }
       }
     }

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -1006,7 +1006,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
           printSuper(st, printedName(qual), checkSymbol = false)
 
         case th @ This(qual) =>
-          if (tree.hasExistingSymbol && tree.symbol.isPackage) print(tree.symbol.fullName)
+          if (tree.hasExistingSymbol && tree.symbol.hasPackageFlag) print(tree.symbol.fullName)
           else printThis(th, printedName(qual))
 
         // remove this prefix from constructor invocation in typechecked trees: this.this -> this
@@ -1023,7 +1023,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
             }) && (tr match { // check that Select contains package
               case Select(q, _) => checkRootPackage(q)
               case _: Ident | _: This => val sym = tr.symbol
-                tr.hasExistingSymbol && sym.isPackage && sym.name != nme.ROOTPKG
+                tr.hasExistingSymbol && sym.hasPackageFlag && sym.name != nme.ROOTPKG
               case _ => false
             })
 

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -362,7 +362,7 @@ abstract class TreeGen {
         if (body forall treeInfo.isInterfaceMember) None
         else Some(
           atPos(wrappingPos(superPos, lvdefs)) (
-            DefDef(NoMods, nme.MIXIN_CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(lvdefs, Literal(Constant())))))
+            DefDef(NoMods, nme.MIXIN_CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(lvdefs, Literal(Constant(()))))))
       }
       else {
         // convert (implicit ... ) to ()(implicit ... ) if its the only parameter section
@@ -376,7 +376,7 @@ abstract class TreeGen {
                                          // therefore here we emit a dummy which gets populated when the template is named and typechecked
         Some(
           atPos(wrappingPos(superPos, lvdefs ::: vparamss1.flatten).makeTransparent) (
-            DefDef(constrMods, nme.CONSTRUCTOR, List(), vparamss1, TypeTree(), Block(lvdefs ::: List(superCall), Literal(Constant())))))
+            DefDef(constrMods, nme.CONSTRUCTOR, List(), vparamss1, TypeTree(), Block(lvdefs ::: List(superCall), Literal(Constant(()))))))
       }
     }
     constr foreach (ensureNonOverlapping(_, parents ::: gvdefs, focus = false))

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -87,7 +87,7 @@ trait Trees extends api.Trees {
 
     private[scala] def copyAttrs(tree: Tree): this.type = {
       rawatt = tree.rawatt
-      tpe = tree.tpe
+      setType(tree.tpe)
       if (hasSymbolField) symbol = tree.symbol
       this
     }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -209,7 +209,7 @@ trait Types
 
   case object UnmappableTree extends TermTree {
     override def toString = "<unmappable>"
-    super.tpe_=(NoType)
+    super.setType(NoType)
     override def tpe_=(t: Type) = if (t != NoType) {
       throw new UnsupportedOperationException("tpe_=("+t+") inapplicable for <empty>")
     }
@@ -247,7 +247,7 @@ trait Types
 
     def companion = {
       val sym = typeSymbolDirect
-      if (sym.isModule && !sym.isPackage) sym.companionSymbol.tpe
+      if (sym.isModule && !sym.hasPackageFlag) sym.companionSymbol.tpe
       else if (sym.isModuleClass && !sym.isPackageClass) sym.sourceModule.companionSymbol.tpe
       else if (sym.isClass && !sym.isModuleClass && !sym.isPackageClass) sym.companionSymbol.info
       else NoType

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -142,7 +142,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       object ConstantArg {
         def enumToSymbol(enum: Enum[_]): Symbol = {
           val staticPartOfEnum = classToScala(enum.getClass).companionSymbol
-          staticPartOfEnum.info.declaration(enum.name: TermName)
+          staticPartOfEnum.info.declaration(TermName(enum.name))
         }
 
         def unapply(schemaAndValue: (jClass[_], Any)): Option[Any] = schemaAndValue match {
@@ -172,7 +172,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       // currently I'm simply sorting the methods to guarantee stability of the output
       override lazy val assocs: List[(Name, ClassfileAnnotArg)] = (
         jann.annotationType.getDeclaredMethods.sortBy(_.getName).toList map (m =>
-          (m.getName: TermName) -> toAnnotArg(m.getReturnType -> m.invoke(jann))
+          TermName(m.getName) -> toAnnotArg(m.getReturnType -> m.invoke(jann))
         )
       )
     }
@@ -937,7 +937,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       val ownerModule: ModuleSymbol =
         if (split > 0) packageNameToScala(fullname take split) else this.RootPackage
       val owner = ownerModule.moduleClass
-      val name = (fullname: TermName) drop split + 1
+      val name = TermName(fullname) drop split + 1
       val opkg = owner.info decl name
       if (opkg.hasPackageFlag)
         opkg.asModule
@@ -988,7 +988,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
               if (name.startsWith(nme.NAME_JOIN_STRING)) coreLookup(name drop 1) else NoSymbol
             }
           if (nme.isModuleName(simpleName))
-            coreLookup(nme.stripModuleSuffix(simpleName).toTermName) map (_.moduleClass)
+            coreLookup(simpleName.dropModule.toTermName) map (_.moduleClass)
           else
             coreLookup(simpleName)
         }

--- a/src/reflect/scala/reflect/runtime/package.scala
+++ b/src/reflect/scala/reflect/runtime/package.scala
@@ -30,9 +30,9 @@ package runtime {
       import c.universe._
       val runtimeClass = c.reifyEnclosingRuntimeClass
       if (runtimeClass.isEmpty) c.abort(c.enclosingPosition, "call site does not have an enclosing class")
-      val scalaPackage = Select(Ident(newTermName("_root_")), newTermName("scala"))
-      val runtimeUniverse = Select(Select(Select(scalaPackage, newTermName("reflect")), newTermName("runtime")), newTermName("universe"))
-      val currentMirror = Apply(Select(runtimeUniverse, newTermName("runtimeMirror")), List(Select(runtimeClass, newTermName("getClassLoader"))))
+      val scalaPackage = Select(Ident(TermName("_root_")), TermName("scala"))
+      val runtimeUniverse = Select(Select(Select(scalaPackage, TermName("reflect")), TermName("runtime")), TermName("universe"))
+      val currentMirror = Apply(Select(runtimeUniverse, TermName("runtimeMirror")), List(Select(runtimeClass, TermName("getClassLoader"))))
       c.Expr[Nothing](currentMirror)(c.WeakTypeTag.Nothing)
     }
   }


### PR DESCRIPTION
- Added `since` to deprecation statement
- Added unit to parameter list
- Removed usage of deprecated method polyType
- Replaced deprecated `isPackage` with `hasPackageFlag`
- Replaced deprecated `getter` with `getterIn`
- Replaced deprecated `debugwarn` with `devWarning`
- Changed switch statement to if else in order to remove a warning
- Replaced deprecated `hasSymbol` with `hasSymbolField`
- Replaced deprecated `setter` with `setterIn`
- Replaced deprecated `newTermName` with `TermName`
- Switched implementation of `init` and `processOptions` to prevent warning
- Replaced deprecated `originalName` with `unexpandedName`
- Replaced deprecated `Console.readLine` with `scala.io.StdIn.readLine`
- Replaced deprecated `startOrPoint` with `start`
- Replaced deprecated `stringToTermName` with `TermName`
- Replaced deprecated `stripModuleSuffix` with `dropModule`
- Replaced deprecated `superSymbol` with `superSymbolIn`
- Replaced deprecated `tpe_=` with `setType`
- Replaced deprecated `typeCheck` with `typecheck`
- Replaced deprecated `CompilationUnit.warning` with `typer.context.warning`
- Replaced deprecated `scala.tools.nsc.util.ScalaClassLoader` with `scala.reflect.internal.util.ScalaClassLoader`
- Replaced deprecated `scala.tools.ListOfNil` with `scala.reflect.internal.util.ListOfNil`
- Replaced deprecated `scala.tools.utils.ScalaClassLoader` with `scala.reflect.internal.util.ScalaClassLoader`
- Replaced deprecated `tpnme` with `typeNames`
- Replaced deprecated `nme` with `termNames`
- Replaced deprecated `emptyValDef` with `noSelfType`
- In `BoxesRunTime` removed unused method and commented out unused values. Did not delete to keep a reference to the values. If they are deleted people might wonder why `1` and `2` are not used.
- Replaced deprecated `scala.tools.nsc.util.AbstractFileClassLoader` with `scala.reflect.internal.util.AbstractFileClassLoader`
